### PR TITLE
Make the recognition of the GMail's landing page stricter

### DIFF
--- a/uncompressed/gmail/webview.js
+++ b/uncompressed/gmail/webview.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = (Franz) => {
   // if the user is on gmail's landing page, go to the login page.
-  if (location.hostname == 'www.google.com') {
+  if (location.hostname == 'www.google.com' && location.href.includes("gmail/about/")) {
     location.href = 'https://accounts.google.com/AccountChooser?service=mail&continue=https://mail.google.com/mail/';
   }
   


### PR DESCRIPTION
Extend the check to include the location's href. Checking only for
hostname could activate the relocation even in cases when it's not
desired - such as after authenticating with SAML and relocating back
to GMail.

Closes: getferdi/ferdi#473