### PR TITLE
Fix icon for Slack March 2020 styles update

### DIFF
--- a/uncompressed/slack/webview.js
+++ b/uncompressed/slack/webview.js
@@ -9,7 +9,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const getTeamIcon = function getTeamIcon(count = 0) {
   let countTeamIconCheck = count;
   let bgUrl = null;
-  const teamMenu = document.querySelector('#team-menu-trigger');
+  const teamMenu = document.querySelector('#team-menu-trigger, .p-ia__sidebar_header__team_name');
 
   if (teamMenu) {
     teamMenu.click();


### PR DESCRIPTION
Slack is rolling out a major styles update. This is breaking the selector for the icon in the Ferdi sidebar. I've updated the selector to cover both the old Slack styles and the new ones because not all workspaces have been migrated yet