### PR TITLE
Fix for packaging not allowing numbers in recipe ids

### DIFF
--- a/scripts/api/package.js
+++ b/scripts/api/package.js
@@ -93,9 +93,9 @@ For more information about the package.json file visit https://github.com/getfer
   }
   let configErrors = [];
   if (!config.id) {
-    configErrors.push("Your package.json contains no 'id' field. This field should contain a unique ID made of lowercase letters (a-z), numbers (0-9), hyphens (-), periods (.), and underscores (_));
+    configErrors.push("Your package.json contains no 'id' field. This field should contain a unique ID made of lowercase letters (a-z), numbers (0-9), hyphens (-), periods (.), and underscores (_)");
   } else if (!/^[a-z0-9._\-]+$/.test(config.id)) {
-    configErrors.push("Your package.json defines an invalid recipe ID. Please make sure the 'id' field only contains lowercase letters (a-z) and hyphens (-)");
+    configErrors.push("Your package.json defines an invalid recipe ID. Please make sure the 'id' field only contains lowercase letters (a-z), numbers (0-9), hyphens (-), periods (.), and underscores (_)");
   }
   if (!config.name) {
     configErrors.push("Your package.json contains no 'name' field. This field should contain the name of the service (e.g. 'Google Keep')");

--- a/scripts/api/package.js
+++ b/scripts/api/package.js
@@ -93,8 +93,8 @@ For more information about the package.json file visit https://github.com/getfer
   }
   let configErrors = [];
   if (!config.id) {
-    configErrors.push("Your package.json contains no 'id' field. This field should contain a unique ID made of lowercase letters (a-z) and hyphens (-)");
-  } else if (!/^[a-z._\-]+$/.test(config.id)) {
+    configErrors.push("Your package.json contains no 'id' field. This field should contain a unique ID made of lowercase letters (a-z), numbers (0-9), hyphens (-), periods (.), and underscores (_));
+  } else if (!/^[a-z0-9._\-]+$/.test(config.id)) {
     configErrors.push("Your package.json defines an invalid recipe ID. Please make sure the 'id' field only contains lowercase letters (a-z) and hyphens (-)");
   }
   if (!config.name) {


### PR DESCRIPTION
Fix for recipe id validity check to allow numbers as at least one existing recipe had numbers in the id but could not update because of this. The regex also allowed periods and underscores so updated the error messages as appropriate.

This is under the assumption that numbers, periods and underscores SHOULD be valid ids. 