### PR TITLE
Fix WhatsApp fullscreen

### DIFF
--- a/uncompressed/whatsapp/service.css
+++ b/uncompressed/whatsapp/service.css
@@ -1,4 +1,4 @@
-.app-wrapper-web .app {
+.app-wrapper-web .two {
     width: 100% !important;
     height: 100% !important;
     top: 0 !important;


### PR DESCRIPTION
WhatsApp is not in fullscreen mode.

At least for me, the container does not have a css class app. It is called 'two'.