### PR TITLE
Mattermost: Fix badge for unread channels when in single team 

### DIFF
--- a/uncompressed/mattermost/webview.js
+++ b/uncompressed/mattermost/webview.js
@@ -4,9 +4,10 @@ module.exports = Franz => {
   const getMessages = function getMessages() {
     const directMessages = document.querySelectorAll('.sidebar--left .has-badge .badge').length;
     const allMessages = document.querySelectorAll('.sidebar--left .has-badge').length - directMessages;
+    const channelMessages = document.querySelectorAll('.sidebar--left .unread-title').length - allMessages;
     const teamDirectMessages = document.querySelectorAll('.team-wrapper .team-container .badge').length;
     const teamMessages = document.querySelectorAll('.team-wrapper .unread').length - teamDirectMessages;
-    Franz.setBadge(directMessages + teamDirectMessages, allMessages + teamMessages);
+    Franz.setBadge(directMessages + teamDirectMessages, allMessages + channelMessages + teamMessages);
   };
 
   Franz.loop(getMessages);

--- a/uncompressed/office365-owa/webview.js
+++ b/uncompressed/office365-owa/webview.js
@@ -19,7 +19,7 @@ module.exports = Franz => {
         return;
       }
 
-      unreadMail = [...folders.parentNode.children].reduce((count, child) => {
+      unreadMail = [...folders.parentNode.parentNode.children].reduce((count, child) => {
         const unread = child.querySelector('.screenReaderOnly');
         return unread && unread.textContent === 'unread'
           ? count + parseInt(unread.previousSibling.textContent, 10)

--- a/uncompressed/office365-owa/webview.js
+++ b/uncompressed/office365-owa/webview.js
@@ -19,7 +19,7 @@ module.exports = Franz => {
         return;
       }
 
-      unreadMail = [...folders.parentNode.parentNode.children].reduce((count, child) => {
+      unreadMail = [...folders.parentNode.children].reduce((count, child) => {
         const unread = child.querySelector('.screenReaderOnly');
         return unread && unread.textContent === 'unread'
           ? count + parseInt(unread.previousSibling.textContent, 10)


### PR DESCRIPTION
The unread notification badge was not shown in mattermost, when you only have unread channels. This seams to happen, when you are in a single team and there is no team-switcher visible.

With my simple change there is now a unread notification badge :-)