### PR TITLE
Gmail getMessages produces wrong value

### DIFF
--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Gmail",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -5,13 +5,13 @@ module.exports = (Franz) => {
   if (location.hostname == 'www.google.com' && location.href.includes("gmail/about/")) {
     location.href = 'https://accounts.google.com/AccountChooser?service=mail&continue=https://mail.google.com/mail/';
   }
-  
+
   const getMessages = function getMessages() {
     let count = 0;
 
-    if (document.getElementsByClassName('J-Ke n0').length > 0) {
-      if (document.getElementsByClassName('J-Ke n0')[0].getAttribute('aria-label') != null) {
-        count = parseInt(document.getElementsByClassName('J-Ke n0')[0].getAttribute('aria-label').replace(/[^0-9.]/g, ''), 10);
+    if (document.getElementsByClassName('bsU').length > 0) {
+      if (document.getElementsByClassName('bsU')[0].innerHTML != null) {
+        count = parseInt(document.getElementsByClassName('bsU')[0].innerHTML.trim(), 10);
       }
     }
 


### PR DESCRIPTION
When the gmail inbox is set to something like priority inbox, the badge count does not lineup with the number displayed next to "Inbox". Instead it is grabbing the total number of unread messages in the traditional inbox. With priority inbox, you could have thousands of messages that have been filtered from your priority inbox, but they are still showing up in the message count.
![image](https://user-images.githubusercontent.com/5900005/93944879-0a670e80-fcf3-11ea-88a0-7012514554f2.png)

I modified getMessages to grab the value displayed next to "Inbox" so that it adjusts according to the type of inbox you have selected.
![image](https://user-images.githubusercontent.com/5900005/93945044-65006a80-fcf3-11ea-9e20-b20b6be9b628.png)
