### PR TITLE
Update Hangouts Chat to display direct and indirect notifications

### DIFF
--- a/recipes/hangoutschat/package.json
+++ b/recipes/hangoutschat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hangoutschat",
   "name": "Hangouts Chat",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Hangouts Chat",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io> and Iván López (ilopmar)",

--- a/recipes/hangoutschat/webview.js
+++ b/recipes/hangoutschat/webview.js
@@ -1,15 +1,21 @@
 module.exports = (Franz) => {
-
   // class corresponding to the mute icon
-  const muteSelector = '.DQy0Rb';
+  const muteSelector = ".DQy0Rb";
 
   // class corresponding to the red badge that is visible for direct messages
-  const directMessageSelector = '.SaMfhe.m9MHid';
+  const directMessageSelector = ".SaMfhe.m9MHid";
 
   // class corresponding to the bold text that is visible for all messages
-  const allMessageSelector = '.IL9EXe.PL5Wwe.dHI9xe.H7du2';
+  const allMessageSelector = ".IL9EXe.PL5Wwe.dHI9xe.H7du2";
 
-  const isMuted = node => !!node.closest('[role="listitem"]').querySelector(muteSelector);
+  const isMuted = (node) => {
+    closestItem = node.closest('[role="listitem"]')
+    if (closestItem) {
+      return !!closestItem.querySelector(muteSelector);
+    } else {
+      return true;
+    }
+  }
 
   const getMessages = function getMessages() {
     let allMessageCount = 0;
@@ -19,7 +25,7 @@ module.exports = (Franz) => {
     document.querySelectorAll(directMessageSelector).forEach((node) => {
       // Hangouts Chat overrides the muted indicator when there is a direct mention
       // Check for the width of the badge element
-      if (!isMuted(node) && node.clientWidth != 0 ) {
+      if (!isMuted(node) && node.clientWidth != 0) {
         directCount += 1;
       }
     });
@@ -36,10 +42,10 @@ module.exports = (Franz) => {
     Franz.setBadge(directCount, indirectCount);
   };
 
-  document.addEventListener('click', (e) => {
+  document.addEventListener("click", (e) => {
     const { tagName, target, href } = e.target;
 
-    if (tagName === 'A' && target === '_blank') {
+    if (tagName === "A" && target === "_blank") {
       e.preventDefault();
       e.stopImmediatePropagation();
       window.open(href);


### PR DESCRIPTION
the `isMuted` function did not work as intended due to the css changes done in Hangouts Chat. By fixing this issue, we get the direct & indirect message counts properly in Hangouts chat now
![image](https://user-images.githubusercontent.com/1255523/94902196-6aa93d80-04b5-11eb-9542-3fd30156a81e.png)


This issue fixes : https://github.com/getferdi/ferdi/issues/953#issuecomment-701440176
