### PR TITLE
More careful Gmail unread count detection

### DIFF
--- a/recipes/gmail/package.json
+++ b/recipes/gmail/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Gmail",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -9,9 +9,12 @@ module.exports = (Franz) => {
   const getMessages = function getMessages() {
     let count = 0;
 
-    if (document.getElementsByClassName('bsU').length > 0) {
-      if (document.getElementsByClassName('bsU')[0].innerHTML != null) {
-        count = parseInt(document.getElementsByClassName('bsU')[0].innerHTML.trim(), 10);
+    const inboxLinks = document.getElementsByClassName('J-Ke n0');
+    if (inboxLinks.length > 0) {
+      const inboxLink = inboxLinks[0];
+      const unreadCounts = inboxLink.parentNode.parentNode.getElementsByClassName('bsU');
+      if (unreadCounts.length > 0) {
+        count = parseInt(unreadCounts[0].innerHTML.trim(), 10);
       }
     }
 


### PR DESCRIPTION
10a670fe33bd7fab841ddaf4674deb11477f2267 changed the unread count detection to grab the number besides the Inbox link instead of the total number of unread messages in the traditional inbox. However, this detection may fail in there are no unread messages in the inbox and report the number of unread messages from a different category instead.

This pull request combines the previous and the combined approach by first finding the "Inbox" link as in the previous approach, but it extracts the number of unread messages from the number beside it (instead of the aria-label with the total number of unread messages).

Thus, the number of unread messages in the (priority) inbox is correctly reported even if there are unread messages in other categories.