### PR TITLE
Spoof Chrome plugins for Skype

### DIFF
--- a/recipes/skype/package.json
+++ b/recipes/skype/package.json
@@ -1,7 +1,7 @@
 {
   "id": "skype",
   "name": "Skype",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Skype",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/recipes/skype/webview.js
+++ b/recipes/skype/webview.js
@@ -3,6 +3,15 @@
 const {  remote: { BrowserWindow } } = require("electron");
 const path = require('path');
 
+const nameDescriptor = Object.getOwnPropertyDescriptor(Plugin.prototype, 'name');
+const getName = nameDescriptor.get;
+Object.defineProperty(Plugin.prototype, 'name', {
+  ...nameDescriptor,
+  get() {
+    return getName.call(this).replace('Chromium', 'Chrome');
+  }
+});
+
 module.exports = (Franz, settings) => {
   const getMessages = function getMessages() {
     let count = 0;


### PR DESCRIPTION
Skype for Web requires either Chrome or Edge, but refuses to cooperate with Chromium. The detection of (non-)Chromium is based on navigator.plugins: https://github.com/Eloston/ungoogled-chromium/issues/1010#issuecomment-643740388

Since we cannot rebuild Chromium to report a different plugin identity as they did it in `ungoogled-chromium`, we instead patch Plugins.prototype to do the spoofing. This is a pure JavaScript approach, but, unlike the JavaScript approach in the issue linked above, it still lets Skype for Web to load.

Closes https://github.com/getferdi/ferdi/issues/973.
