### PR TITLE
Fix messages count for Fastmail (#335)

### DIFF
--- a/recipes/fastmail/webview.js
+++ b/recipes/fastmail/webview.js
@@ -12,7 +12,7 @@ module.exports = (Franz, options) => {
     clearInterval(interval);
   }, 200);
   const getMessages = () => {
-    const inbox = document.querySelector(".v-FolderSource--inbox>.v-FolderSource-badge");
+    const inbox = document.querySelector(".v-MailboxSource--inbox .v-MailboxSource-badge");
     if (!inbox) {
       return;
     }


### PR DESCRIPTION
Update webview.js to use updated CSS classes and get message count working again.
Fixes #335 .