### PR TITLE
Nextcloud Calendar: Display only calendar related notifications and their count

### DIFF
--- a/recipes/nextcloud-calendar/package.json
+++ b/recipes/nextcloud-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-calendar",
   "name": "Nextcloud Calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ferdi recipe for Nextcloud Calendar.",
   "main": "index.js",
   "author": "Edgars Andersons <Edgars+github@gaitenis.id.lv>",

--- a/recipes/nextcloud-calendar/service.css
+++ b/recipes/nextcloud-calendar/service.css
@@ -10,3 +10,8 @@ settings links and disable them */
 
 /* Hide "More" link in the top menu */
 #more-apps {display: none !important;}
+
+/* Hide notifications that are not related to calendar */
+.notifications .notification-wrapper .notification:not([object_type="dav"]) {
+    display: none;
+}

--- a/recipes/nextcloud-calendar/service.css
+++ b/recipes/nextcloud-calendar/service.css
@@ -15,3 +15,7 @@ settings links and disable them */
 .notifications .notification-wrapper .notification:not([object_type="dav"]) {
     display: none;
 }
+
+/* Hide "Dismiss all notifications" as this action will dismiss also hidden
+notifications */
+.notification-wrapper .dismiss-all {display: none;}

--- a/recipes/nextcloud-calendar/webview.js
+++ b/recipes/nextcloud-calendar/webview.js
@@ -6,18 +6,15 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
 
-module.exports = Franz => {
+module.exports = Ferdi => {
   const getMessages = function getMessages() {
     const direct = document.querySelectorAll(
-      '.app-navigation-entry-utils-counter.highlighted'
-    ).length;
-    const indirect = document.querySelectorAll(
-      '.app-navigation-entry-utils-counter:not(.highlighted)'
+      '.notifications .notification-wrapper .notification[object_type="dav"]'
     ).length;
 
-    Franz.setBadge(direct, indirect);
+    Ferdi.setBadge(direct);
   };
 
-  Franz.loop(getMessages);
-  Franz.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdi.loop(getMessages);
+  Ferdi.injectCSS(_path.default.join(__dirname, 'service.css'));
 };


### PR DESCRIPTION
`service.css` was updated to hide notifications that are not related to Nextcloud Calendar and "Dismiss all notifications" as this action would dismiss hidden notifications as well.
`webview.js` was updated to fix notifications count selector.
