### PR TITLE
Nextcloud Talk: Hide unrelated notifications and fix notifications count

### DIFF
--- a/recipes/nextcloud-talk/README.md
+++ b/recipes/nextcloud-talk/README.md
@@ -1,0 +1,21 @@
+# Ferdi recipe for Nextcloud Talk
+
+Nextcloud Talk - Chat, video & audio-conferencing using WebRTC.
+
+To add Nextcloud Talk to Ferdi, Nextcloud server address should be provided in the field "Custom server".
+
+## Credits
+
+This recipe is based on [`recipe-nextcloud-talk`](https://github.com/meetfranz/recipe-nextcloud-talk).
+
+## Links
+
+Ferdi:
+
+- [Ferdi](https://getferdi.com/)
+- [Ferdi recipes](https://github.com/getferdi/recipes)
+
+Nextcloud:
+
+- [Nextcloud](https://nextcloud.com/)
+- [Nextcloud Talk](https://apps.nextcloud.com/apps/spreed)

--- a/recipes/nextcloud-talk/package.json
+++ b/recipes/nextcloud-talk/package.json
@@ -2,7 +2,7 @@
   "id": "nextcloud-talk",
   "name": "Nextcloud Talk",
   "version": "1.0.2",
-  "description": "Nextcloud Talk",
+  "description": "Nextcloud Talk - chat, video & audio-conferencing using WebRTC",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",
   "license": "MIT",

--- a/recipes/nextcloud-talk/package.json
+++ b/recipes/nextcloud-talk/package.json
@@ -1,7 +1,7 @@
 {
   "id": "nextcloud-talk",
   "name": "Nextcloud Talk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Nextcloud Talk - chat, video & audio-conferencing using WebRTC",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/recipes/nextcloud-talk/service.css
+++ b/recipes/nextcloud-talk/service.css
@@ -15,7 +15,13 @@ settings links and disable them */
   display: none !important;
 }
 
-/* Hide contacts in the top menu */
-#contactsmenu {
-  display: none;
+/* Hide notifications that are not related to calendar */
+.notifications .notification-wrapper .notification {display: none;}
+.notifications .notification-wrapper .notification[object_type="chat"],
+.notifications .notification-wrapper .notification[object_type="room"]  {
+  display: initial;
 }
+
+/* Hide "Dismiss all notifications" as this action will dismiss also hidden
+notifications */
+.notification-wrapper .dismiss-all {display: none;}

--- a/recipes/nextcloud-talk/webview.js
+++ b/recipes/nextcloud-talk/webview.js
@@ -8,17 +8,22 @@ function _interopRequireDefault(obj) {
 
 module.exports = Ferdi => {
   const getMessages = function getMessages() {
-    const direct =  document.querySelector(
+    let direct = 0;
+    const notificationWrapper = document.querySelector(
       '.notifications .notification-wrapper'
-    ).querySelectorAll(
-      '.notification[object_type="chat"], .notification[object_type="room"'
-    ).length;
+    );
 
-    var indirect = 0;
+    if (notificationWrapper) {
+      direct = notificationWrapper.querySelectorAll(
+        '.notification[object_type="chat"], .notification[object_type="room"'
+      ).length;
+    }
+
+    let indirect = 0;
 
     document.querySelectorAll('.app-navigation-entry__counter').forEach(
       function(counter) {
-        indirect += Number(counter.textContent)
+        indirect += Number(counter.textContent);
       }
     );
     Ferdi.setBadge(direct, indirect);

--- a/recipes/nextcloud-talk/webview.js
+++ b/recipes/nextcloud-talk/webview.js
@@ -6,13 +6,24 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
-module.exports = Franz => {
+module.exports = Ferdi => {
   const getMessages = function getMessages() {
-    const direct = document.querySelectorAll('.app-navigation-entry-utils-counter.highlighted').length;
-    const indirect = document.querySelectorAll('.app-navigation-entry-utils-counter:not(.highlighted)').length;
-    Franz.setBadge(direct, indirect);
+    const direct =  document.querySelector(
+      '.notifications .notification-wrapper'
+    ).querySelectorAll(
+      '.notification[object_type="chat"], .notification[object_type="room"'
+    ).length;
+
+    var indirect = 0;
+
+    document.querySelectorAll('.app-navigation-entry__counter').forEach(
+      function(counter) {
+        indirect += Number(counter.textContent)
+      }
+    );
+    Ferdi.setBadge(direct, indirect);
   };
 
-  Franz.loop(getMessages);
-  Franz.injectCSS(_path.default.join(__dirname, 'service.css'));
+  Ferdi.loop(getMessages);
+  Ferdi.injectCSS(_path.default.join(__dirname, 'service.css'));
 };


### PR DESCRIPTION
`service.css` was updated to:

- unhide contacts menu;
- hide notifications that are not related to Nextcloud Talk;
- hide "Dismiss all notifications" as this action would also dismiss hidden
  notifications.

`webview.js` was updated to fix notifications (both direct and indirect) count retrieval.

`README.md` was added.