### PR TITLE
Fix for Dark Mode

### DIFF
--- a/recipes/instagram/webview.js
+++ b/recipes/instagram/webview.js
@@ -12,4 +12,18 @@ module.exports = (Franz) => {
   Franz.loop(getMessages);
 
   Franz.injectCSS(path.join(__dirname, 'service.css'));
+  
+  // https://github.com/getferdi/recipes/blob/9d715597a600710c20f75412d3dcd8cdb7b3c39e/docs/frontend_api.md#usage-4
+  // Helper that activates DarkReader and injects your darkmode.css at the same time
+  Franz.handleDarkMode((isEnabled, helpers) => {
+    if (isEnabled) {
+      helpers.enableDarkMode();
+      if (!helpers.isDarkModeStyleInjected()) {
+        helpers.injectDarkModeStyle();
+      }
+    } else {
+      helpers.disableDarkMode();
+      helpers.removeDarkModeStyle();
+    }
+  })
 };


### PR DESCRIPTION
Enabling Dark Mode for Instagram did not work correctly for me on Windows 10. The below code fixed the issue for me. 