### PR TITLE
Fix null element for proton-mail

### DIFF
--- a/recipes/proton-mail/webview.js
+++ b/recipes/proton-mail/webview.js
@@ -1,7 +1,16 @@
 module.exports = Franz => {
     function getMessages() {
-        const count = document.querySelector('.navigationItem-counter').innerText
-        Franz.setBadge(count ? Number(count.substring(1, count.length - 1)) : 0)
+        const element = document.querySelector('.navigationItem-counter')
+        if (!element) {
+            return
+        }
+        const text = element.innerText
+        const count = Number(text.substring(1, text.length - 1))
+        if (Number.isNaN(count)) {
+            return
+        }
+        Franz.setBadge(count)
     }
+
     Franz.loop(getMessages)
 }


### PR DESCRIPTION
Fix the following error when the element is not displayed

<img width="672" alt="Screenshot 2021-02-01 at 15 13 44" src="https://user-images.githubusercontent.com/352607/106471123-9e1ac980-64a1-11eb-92fc-1ddad5ee96b7.png">

