### PR TITLE
issue with gmail popup link not working -- fix

### DIFF
--- a/recipes/gmail/index.js
+++ b/recipes/gmail/index.js
@@ -1,17 +1,18 @@
-var os = require('os')
+var os = require("os");
 
-module.exports = Franz =>
+module.exports = (Franz) =>
   class Gmail extends Franz {
     modifyRequestHeaders() {
       return [
         {
           headers: {
-            'user-agent': window.navigator.userAgent.replace(/(Ferdi|Electron)\/\S+ \([^)]+\)/g,"").trim(),
+            "user-agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
           },
           requestFilters: {
-            urls: ['*://*/*'],
-          }
-        }
-      ]
+            urls: ["*://*/*"],
+          },
+        },
+      ];
     }
   };


### PR DESCRIPTION
This is the fix for the issue where when you click on a link on Gmail, it doesn't redirect you to the link. 

The fix was inspired by the thread in [Ferdi issue 321](https://github.com/getferdi/ferdi/issues/321).

This issue seems to exist in other Gmail recipes (Google Classroom for example), but this pull request is only for Gmail. 