### PR TITLE
Fixing issue with image preview not working in gChat.

### DIFF
--- a/recipes/hangoutschat/index.js
+++ b/recipes/hangoutschat/index.js
@@ -3,20 +3,4 @@ var os = require('os')
 // just pass through Franz
 module.exports = Franz =>
   class HangoutsChat extends Franz {
-    // Method to add headers to requests from Hangouts Chat's webview
-    modifyRequestHeaders() {
-      return [{
-        headers: { 'origin': 'https://chat.google.com' },
-        requestFilters: {
-          urls: ['*://*/*']
-        }
-      }]
-    }
-
-    overrideUserAgent() {
-      if (os.platform() == 'linux')
-        return "Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0"
-      else
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0";
-    }
   };


### PR DESCRIPTION
Commenting out the overrides for the header and user-agent fixes the following [issue](https://github.com/getferdi/ferdi/issues/1283).

Tested on:
Version 5.6.0-nightly.18 (5.6.0-nightly.18)

[git SHA](https://github.com/getferdi/ferdi/commit/d8d11a5f63525bfe2e0578ab7106f6a941f81533) for the ferdi code repo