### PR TITLE
Gitlab: enable option to provide url of self-hosted instance (2)

### DIFF
--- a/recipes/gitlab/package.json
+++ b/recipes/gitlab/package.json
@@ -1,12 +1,14 @@
 {
   "id": "gitlab",
   "name": "GitLab",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An unofficial Ferdi recipe for GitLab CI",
   "main": "index.js",
   "author": "Kittywhiskers Van Gogh <63189531+kittywhiskers@users.noreply.github.com>",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://gitlab.com/users/sign_in"
+    "serviceURL": "https://gitlab.com/users/sign_in",
+    "hasHostedOption": true,
+    "hasCustomUrl": true
   }
 }


### PR DESCRIPTION
Gitlab can be self-hosted.
I saw that from Ferdi v5.0.0-beta.15 it is possible to define the hasHostedOption param in recipes. This would allow an user to declare the url of a self-hosted Gitlab instance.