### PR TITLE
Version bump enforced in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,21 @@
         }
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -4349,6 +4364,17 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-git": {
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.39.0.tgz",
+      "integrity": "sha512-VOsrmc3fpp1lGVIpo+1SKNqJzrdVJeSGZCeenPKnJPNo5UouAlSkWFc037pfm9wRYtfxBdwp2deVJGCG8J6C8A==",
+      "dev": true,
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.1"
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "eslint": "^5.10.0",
     "husky": "^6.0.0",
     "imagemin-cli": "^6.0.0",
-    "prettier": "^2.3.0"
+    "prettier": "^2.3.0",
+    "simple-git": "^2.39.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Added check for verifying that the `package.json` file has a `version` change if there are other changes in the same recipe. This is now enforced when running `npm run package`.