### PR TITLE
Fixing calendar recipe to enable dark reader

### DIFF
--- a/all.json
+++ b/all.json
@@ -84,7 +84,7 @@
     "featured": false,
     "id": "basecamp",
     "name": "basecamp",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/basecamp/icon.svg"
     }
@@ -504,7 +504,7 @@
     "featured": false,
     "id": "googlecalendar",
     "name": "Google Calendar",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/googlecalendar/icon.svg"
     }

--- a/recipes/basecamp/package.json
+++ b/recipes/basecamp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "basecamp",
   "name": "basecamp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Basecamp plugin for ferdi.",
   "main": "index.js",
   "author": "",

--- a/recipes/basecamp/webview.js
+++ b/recipes/basecamp/webview.js
@@ -4,6 +4,13 @@ module.exports = (Franz, options) => {
   let updates = 0;
   const modal = document.createElement('div');
 
+  const waitFor = (condition, callback) => {
+    if (!condition()) {
+      window.setTimeout(waitFor.bind(null, condition, callback), 100);
+    } else {
+      callback();
+    }
+  };
   function showModal (text) {
     show(modal);
     modal.querySelector('p').innerHTML = text;
@@ -47,7 +54,7 @@ module.exports = (Franz, options) => {
   modal.id = 'franz-modal';
   modal.innerHTML = '<div class="modal-content"><span class="close">&times;</span><p></p></div>';
   modal.querySelector('.close').addEventListener('click', hideModal);
-  document.body.appendChild(modal);
+  waitFor(() => document.body, () => document.body.appendChild(modal));
 
   document.addEventListener('keydown', function(e) { if (e.keyCode === 27) { hideModal(); } })
 

--- a/recipes/googlecalendar/package.json
+++ b/recipes/googlecalendar/package.json
@@ -1,7 +1,7 @@
 {
   "id": "googlecalendar",
   "name": "Google Calendar",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Google Calendar",
   "main": "index.js",
   "author": "Rico Herwig <rherwig4711@gmail.com>",

--- a/recipes/googlecalendar/webview.js
+++ b/recipes/googlecalendar/webview.js
@@ -6,6 +6,14 @@ module.exports = Franz => {
   let modal;
   let updates = 0;
 
+  const waitFor = (condition, callback) => {
+    if (!condition()) {
+      window.setTimeout(waitFor.bind(null, condition, callback), 100);
+    } else {
+      callback();
+    }
+  };
+
   const createModal = () => {
     const franzModal = document.createElement('div');
     franzModal.setAttribute('id', 'franz-modal');
@@ -32,7 +40,7 @@ module.exports = Franz => {
   const getMessages = () => Franz.setBadge(updates);
 
   modal = createModal();
-  document.body.appendChild(modal);
+  waitFor(() => document.body, () => document.body.appendChild(modal));
   document.addEventListener('keydown', event => event.keyCode === 27 && hideModal());
 
   Franz.injectCSS(path.join(__dirname, 'calendar.css'));


### PR DESCRIPTION
**Issue**

Inside calendar recipe, we are creating a modal and replace `window.alert` As part of this, we are attaching a modal to a dom. But due to a race condition, the `document.body` isn't present causing an undefined exception. 

Due to this exception, "Enabling dark mode" isn't working since the recipe isn't fully loaded.

**Fix**
Now, we are waiting for the `document.body` to be present before attaching the modal. This eliminates the error and loads the recipe successfully.

This resolved the calendar issue mentioned here: https://github.com/getferdi/ferdi/issues/1604 


