### PR TITLE
Fix Screen Share not working on Discord

### DIFF
--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -29,3 +29,64 @@ module.exports = Franz => {
   Franz.loop(getMessages);
   Franz.injectCSS(_path.default.join(__dirname, 'service.css'));
 };
+
+// Polyfill to enable Screen Sharing
+// See https://github.com/electron/electron/issues/16513#issuecomment-602070250
+const { desktopCapturer } = require('electron')
+window.navigator.mediaDevices.getDisplayMedia = () => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const sources = await desktopCapturer.getSources({ types: ['screen', 'window'] })
+
+      const selectionElem = document.createElement('div')
+      selectionElem.classList = 'desktop-capturer-selection'
+      selectionElem.innerHTML = `
+        <div class="desktop-capturer-selection__scroller">
+          <ul class="desktop-capturer-selection__list">
+            ${sources.map(({id, name, thumbnail, display_id, appIcon}) => `
+              <li class="desktop-capturer-selection__item">
+                <button class="desktop-capturer-selection__btn" data-id="${id}" title="${name}">
+                  <img class="desktop-capturer-selection__thumbnail" src="${thumbnail.toDataURL()}" />
+                  <span class="desktop-capturer-selection__name">${name}</span>
+                </button>
+              </li>
+            `).join('')}
+          </ul>
+        </div>
+      `
+      document.body.appendChild(selectionElem)
+
+      document.querySelectorAll('.desktop-capturer-selection__btn')
+        .forEach(button => {
+          button.addEventListener('click', async () => {
+            try {
+              const id = button.getAttribute('data-id')
+              const source = sources.find(source => source.id === id)
+              if(!source) {
+                throw new Error(`Source with id ${id} does not exist`)
+              }
+              
+              const stream = await window.navigator.mediaDevices.getUserMedia({
+                audio: false,
+                video: {
+                  mandatory: {
+                    chromeMediaSource: 'desktop',
+                    chromeMediaSourceId: source.id
+                  }
+                }
+              })
+              resolve(stream)
+
+              selectionElem.remove()
+            } catch (err) {
+              console.error('Error selecting desktop capture source:', err)
+              reject(err)
+            }
+          })
+        })
+    } catch (err) {
+      console.error('Error displaying desktop capture sources:', err)
+      reject(err)
+    }
+  })
+}

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -33,7 +33,7 @@ module.exports = Franz => {
 // Polyfill to enable Screen Sharing
 // See https://github.com/electron/electron/issues/16513#issuecomment-602070250
 const { desktopCapturer } = require('electron')
-window.navigator.mediaDevices.getDisplayMedia = () => {
+navigator.mediaDevices.getDisplayMedia = () => {
   return new Promise(async (resolve, reject) => {
     try {
       const sources = await desktopCapturer.getSources({ types: ['screen', 'window'] })
@@ -41,7 +41,87 @@ window.navigator.mediaDevices.getDisplayMedia = () => {
       const selectionElem = document.createElement('div')
       selectionElem.classList = 'desktop-capturer-selection'
       selectionElem.innerHTML = `
+        <style>
+        .close {
+            color: #fff;
+            font: 50px/100% arial, sans-serif;
+            position: absolute;
+            right: 5px;
+            text-decoration: none;
+            text-shadow: 0 1px 0 #fff;
+            top: 5px;
+            padding: 0;
+            border: none;
+            background: none;
+          }
+        .close:after {
+            content: '✖'; /* UTF-8 symbol */
+          }
+        .desktop-capturer-selection {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100vh;
+          background: rgba(30,30,30,.75);
+          color: #fff;
+          z-index: 10000000;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .desktop-capturer-selection__scroller {
+          width: 100%;
+          max-height: 100vh;
+          overflow-y: auto;
+        }
+        .desktop-capturer-selection__list {
+          max-width: calc(100% - 100px);
+          margin: 50px;
+          padding: 0;
+          display: flex;
+          flex-wrap: wrap;
+          list-style: none;
+          overflow: hidden;
+          justify-content: center;
+        }
+        .desktop-capturer-selection__item {
+          display: flex;
+          margin: 4px;
+        }
+        .desktop-capturer-selection__btn {
+          display: flex;
+          flex-direction: column;
+          align-items: stretch;
+          width: 145px;
+          margin: 0;
+          border: 0;
+          border-radius: 3px;
+          padding: 4px;
+          background: #252626;
+          text-align: left;
+          transition: background-color .15s, box-shadow .15s;
+        }
+        .desktop-capturer-selection__btn:hover,
+        .desktop-capturer-selection__btn:focus {
+          background: rgba(98,100,167,.8);
+        }
+        .desktop-capturer-selection__thumbnail {
+          width: 100%;
+          height: 81px;
+          object-fit: cover;
+        }
+        .desktop-capturer-selection__name {
+          margin: 6px 0 6px;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+        </style>
+
         <div class="desktop-capturer-selection__scroller">
+          <button class="close"></button>
+
           <ul class="desktop-capturer-selection__list">
             ${sources.map(({id, name, thumbnail, display_id, appIcon}) => `
               <li class="desktop-capturer-selection__item">
@@ -51,6 +131,7 @@ window.navigator.mediaDevices.getDisplayMedia = () => {
                 </button>
               </li>
             `).join('')}
+			
           </ul>
         </div>
       `
@@ -65,8 +146,8 @@ window.navigator.mediaDevices.getDisplayMedia = () => {
               if(!source) {
                 throw new Error(`Source with id ${id} does not exist`)
               }
-              
-              const stream = await window.navigator.mediaDevices.getUserMedia({
+
+              const stream = await navigator.mediaDevices.getUserMedia({
                 audio: false,
                 video: {
                   mandatory: {
@@ -84,9 +165,20 @@ window.navigator.mediaDevices.getDisplayMedia = () => {
             }
           })
         })
+
+        document.querySelectorAll('.close')
+        .forEach(button => {
+          button.addEventListener('click', async () => {
+            reject("Closed")
+            selectionElem.remove();
+            console.log("CLOSE");
+            })
+          }
+        )
     } catch (err) {
       console.error('Error displaying desktop capture sources:', err)
       reject(err)
     }
-  })
-}
+	
+  });
+};


### PR DESCRIPTION
Adds a polyfill that replaces Discord's non-working native screen share window for a very basic working one.
See https://github.com/electron/electron/issues/16513#issuecomment-602070250 for more information.

---

Screen Share window on a chromium browser
![image](https://user-images.githubusercontent.com/10510126/126242941-7ead2f9e-e3c6-459e-adbb-978fcf154184.png)

Screen share on Discord's own app
![image](https://user-images.githubusercontent.com/10510126/126244082-e3e31b10-21ce-4fc3-87d2-ee740bbd0690.png)

Replacement Screen Share window introduced by this PR
![image](https://user-images.githubusercontent.com/10510126/126243179-4f6483de-7c84-4372-bf9d-3edee62d4aa0.png)
_Despite the design change, the only thing missing is a close button._

Screen share working on Ferdi 5.6
![image](https://user-images.githubusercontent.com/10510126/126243608-ebb6e38f-1697-4ff2-9be1-49dbef9b0fef.png)

_PS.: While this works most of the time, sometimes the shared screen will flicker, restarting the transmission a few times seems to fix this. No idea what might be the cause._

---

Theoretically we could apply this to other problematic services mentioned on https://github.com/getferdi/ferdi/issues/1541, requires testing though.