### PR TITLE
Fix images opening in browser instead of in Discord

### DIFF
--- a/all.json
+++ b/all.json
@@ -297,7 +297,7 @@
     "featured": true,
     "id": "discord",
     "name": "Discord",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/discord/icon.svg"
     }

--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discordapp.com/login",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -93,10 +93,10 @@ module.exports = (Ferdi, settings) => {
 
     if (link || button) {
       const url = link ? link.getAttribute('href') : button.getAttribute('title');
-      event.preventDefault();
-      event.stopPropagation();
 
       if (url.includes('views/imgpsh_fullsize_anim')) {
+        event.preventDefault();
+        event.stopPropagation();
         let win = new Ferdi.BrowserWindow({
           width: 800,
           height: window.innerHeight,
@@ -109,8 +109,6 @@ module.exports = (Ferdi, settings) => {
         win.on('closed', () => {
           win = null;
         });
-      } else {
-        window.open(url);
       }
     }
   }, true);


### PR DESCRIPTION
fe613088a813394760ca27afeee554cfa7290d67 introduced a bug where clicking an image in Discord would cause it to open in the default browser rather than displaying full size within Discord itself. This may potentially fix other bugs as the recipe was programmed to open any link in a browser rather than letting Discord itself handle it. Hopefully it doesn't introduce any new bugs as well.