### PR TITLE
fix: privileged API access

### DIFF
--- a/all.json
+++ b/all.json
@@ -42,7 +42,7 @@
     "featured": false,
     "id": "android-messages",
     "name": "Android Messages",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/android-messages/icon.svg"
     }
@@ -270,7 +270,7 @@
     "featured": false,
     "id": "devRant",
     "name": "devRant",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/devRant/icon.svg"
     }
@@ -297,7 +297,7 @@
     "featured": true,
     "id": "discord",
     "name": "Discord",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/discord/icon.svg"
     }
@@ -876,7 +876,7 @@
     "featured": false,
     "id": "lastpass",
     "name": "LastPass",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/lastpass/icon.svg"
     }
@@ -975,7 +975,7 @@
     "featured": false,
     "id": "msteams",
     "name": "Microsoft Teams",
-    "version": "3.1.4",
+    "version": "3.1.5",
     "aliases": [
       "teamsChat"
     ],
@@ -1350,7 +1350,7 @@
     "featured": false,
     "id": "rocketchat",
     "name": "Rocket.Chat",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/rocketchat/icon.svg"
     }
@@ -1413,7 +1413,7 @@
     "featured": true,
     "id": "slack",
     "name": "Slack",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/slack/icon.svg"
     }
@@ -1656,7 +1656,7 @@
     "featured": true,
     "id": "tweetdeck",
     "name": "Tweetdeck",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/tweetdeck/icon.svg"
     }
@@ -1773,7 +1773,7 @@
     "featured": true,
     "id": "whatsapp",
     "name": "WhatsApp",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/whatsapp/icon.svg"
     }

--- a/all.json
+++ b/all.json
@@ -611,7 +611,7 @@
     "featured": false,
     "id": "googlemeet",
     "name": "Google Meet",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/googlemeet/icon.svg"
     }

--- a/recipes/android-messages/package.json
+++ b/recipes/android-messages/package.json
@@ -1,7 +1,7 @@
 {
   "id": "android-messages",
   "name": "Android Messages",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messages.google.com/web",

--- a/recipes/android-messages/webview.js
+++ b/recipes/android-messages/webview.js
@@ -7,16 +7,16 @@ setTimeout(() => {
   }
 }, 1000);
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
-  Ferdi.releaseServiceWorkers();
-});
-
 module.exports = (Ferdi, settings) => {
   function getMessages() {
     const messages = document.querySelectorAll('.text-content.unread').length;
     Ferdi.setBadge(messages);
   }
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
+    Ferdi.releaseServiceWorkers();
+  });
 
   Ferdi.loop(getMessages);
 

--- a/recipes/devRant/package.json
+++ b/recipes/devRant/package.json
@@ -1,7 +1,7 @@
 {
   "id": "devRant",
   "name": "devRant",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "repository": "https://github.com/emamut/recipe-devrant",
   "config": {

--- a/recipes/devRant/webview.js
+++ b/recipes/devRant/webview.js
@@ -9,11 +9,6 @@ setTimeout(() => {
   }
 }, 1000);
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
-  Ferdi.releaseServiceWorkers();
-});
-
 module.exports = (Ferdi) => {
   const getMessages = function getMessages() {
     const elements = document.querySelectorAll('.CxUIE, .unread, ._0LqQ');
@@ -26,6 +21,11 @@ module.exports = (Ferdi) => {
 
     Ferdi.setBadge(count);
   };
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
+    Ferdi.releaseServiceWorkers();
+  });
 
   Ferdi.loop(getMessages);
   Ferdi.injectCSS(_path.default.join(__dirname, 'service.css'));

--- a/recipes/discord/package.json
+++ b/recipes/discord/package.json
@@ -1,7 +1,7 @@
 {
   "id": "discord",
   "name": "Discord",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://discordapp.com/login",

--- a/recipes/discord/webview.js
+++ b/recipes/discord/webview.js
@@ -1,64 +1,6 @@
-// TODO: Some/most of this is already present in https://github.com/getferdi/ferdi/blob/develop/src/webview/screenshare.js#L5
-
 const _path = _interopRequireDefault(require('path'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-window.navigator.mediaDevices.getDisplayMedia = () => {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const sources = await Ferdi.desktopCapturer.getSources({ types: ['screen', 'window'] });
-
-      const selectionElem = document.createElement('div');
-      selectionElem.classList = 'desktop-capturer-selection';
-      selectionElem.innerHTML = `
-        <div class="desktop-capturer-selection__scroller">
-          <ul class="desktop-capturer-selection__list">
-            ${sources.map(({ id, name, thumbnail, display_id, appIcon }) => `
-              <li class="desktop-capturer-selection__item">
-                <button class="desktop-capturer-selection__btn" data-id="${id}" title="${name}">
-                  <img class="desktop-capturer-selection__thumbnail" src="${thumbnail.toDataURL()}" />
-                  <span class="desktop-capturer-selection__name">${name}</span>
-                </button>
-              </li>
-            `).join('')}
-          </ul>
-        </div>
-      `;
-      document.body.appendChild(selectionElem);
-
-      document.querySelectorAll('.desktop-capturer-selection__btn')
-        .forEach(button => {
-          button.addEventListener('click', async () => {
-            try {
-              const id = button.getAttribute('data-id');
-              const source = sources.find(source => source.id === id);
-              if (!source) {
-                throw new Error(`Source with id ${id} does not exist`);
-              }
-
-              const stream = await window.navigator.mediaDevices.getUserMedia({
-                audio: false,
-                video: {
-                  mandatory: {
-                    chromeMediaSource: 'desktop',
-                    chromeMediaSourceId: source.id
-                  }
-                }
-              });
-              resolve(stream);
-
-              selectionElem.remove();
-            } catch (err) {
-              reject(err);
-            }
-          });
-        });
-    } catch (err) {
-      reject(err);
-    }
-  })
-}
 
 module.exports = (Ferdi, settings) => {
   const getMessages = function getMessages() {

--- a/recipes/googlemeet/package.json
+++ b/recipes/googlemeet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "googlemeet",
   "name": "Google Meet",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://meet.google.com",

--- a/recipes/googlemeet/webview.js
+++ b/recipes/googlemeet/webview.js
@@ -10,10 +10,6 @@ window.onload = () => {
   }
 };
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['serviceworkers']);
-});
-
 module.exports = Ferdi => {
   const getMessages = function getMessages() {
     const elements = document.querySelectorAll('.CxUIE, .unread');
@@ -29,6 +25,10 @@ module.exports = Ferdi => {
   };
 
   Ferdi.loop(getMessages);
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['serviceworkers']);
+  });
 
   Ferdi.injectCSS(_path.default.join(__dirname, 'service.css'));
 };

--- a/recipes/lastpass/package.json
+++ b/recipes/lastpass/package.json
@@ -1,7 +1,7 @@
 {
   "id": "lastpass",
   "name": "LastPass",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "config": {
     "serviceURL": "https://lastpass.com/?ac=1&lpnorefresh=1",

--- a/recipes/lastpass/webview.js
+++ b/recipes/lastpass/webview.js
@@ -8,11 +8,6 @@ setTimeout(() => {
   }
 }, 1000);
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
-  Ferdi.releaseServiceWorkers();
-});
-
 module.exports = Ferdi => {
   const getMessages = function getMessages() {
     const elements = document.querySelectorAll('.CxUIE, .unread');
@@ -26,6 +21,11 @@ module.exports = Ferdi => {
 
     Ferdi.setBadge(count);
   };
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
+    Ferdi.releaseServiceWorkers();
+  });
 
   Ferdi.loop(getMessages);
 

--- a/recipes/msteams/package.json
+++ b/recipes/msteams/package.json
@@ -1,7 +1,7 @@
 {
   "id": "msteams",
   "name": "Microsoft Teams",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "license": "MIT",
   "aliases": [
     "teamsChat"

--- a/recipes/msteams/webview.js
+++ b/recipes/msteams/webview.js
@@ -2,11 +2,6 @@ const _path = _interopRequireDefault(require('path'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
-  Ferdi.releaseServiceWorkers();
-});
-
 module.exports = Ferdi => {
   const getMessages = () => {
     let messages = 0;
@@ -19,6 +14,11 @@ module.exports = Ferdi => {
 
     Ferdi.setBadge(messages, indirectMessages);
   };
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
+    Ferdi.releaseServiceWorkers();
+  });
 
   Ferdi.loop(getMessages);
 

--- a/recipes/rocketchat/package.json
+++ b/recipes/rocketchat/package.json
@@ -1,7 +1,7 @@
 {
   "id": "rocketchat",
   "name": "Rocket.Chat",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.rocket.chat",

--- a/recipes/rocketchat/webview.js
+++ b/recipes/rocketchat/webview.js
@@ -1,36 +1,3 @@
-const getTeamIcon = function getTeamIcon() {
-  const manifestElement = document.querySelector('link[rel="manifest"]');
-
-  if (manifestElement == null) {
-    return;
-  }
-
-  const manifestUrl = manifestElement.getAttribute('href');
-
-  if (manifestUrl == null) {
-    return;
-  }
-
-  const xmlhttp = new XMLHttpRequest();
-
-  xmlhttp.onreadystatechange = function () {
-    if (this.readyState != 4 || this.status != 200) {
-      return;
-    }
-
-    const response = JSON.parse(this.responseText);
-
-    if (response.icons.length >= 1) {
-      Ferdi.ipcRenderer.sendToHost(
-        'avatar',
-        `${window.location.protocol}//${window.location.host}${response.icons[0].src}`,
-      );
-    }
-  };
-
-  xmlhttp.open('GET', manifestUrl, true);
-  xmlhttp.send();
-};
 
 module.exports = Ferdi => {
   const getMessages = function getMessages() {
@@ -50,6 +17,40 @@ module.exports = Ferdi => {
   };
 
   Ferdi.loop(getMessages);
+
+  const getTeamIcon = function getTeamIcon() {
+    const manifestElement = document.querySelector('link[rel="manifest"]');
+
+    if (manifestElement == null) {
+      return;
+    }
+
+    const manifestUrl = manifestElement.getAttribute('href');
+
+    if (manifestUrl == null) {
+      return;
+    }
+
+    const xmlhttp = new XMLHttpRequest();
+
+    xmlhttp.onreadystatechange = function () {
+      if (this.readyState != 4 || this.status != 200) {
+        return;
+      }
+
+      const response = JSON.parse(this.responseText);
+
+      if (response.icons.length >= 1) {
+        Ferdi.ipcRenderer.sendToHost(
+          'avatar',
+          `${window.location.protocol}//${window.location.host}${response.icons[0].src}`,
+        );
+      }
+    };
+
+    xmlhttp.open('GET', manifestUrl, true);
+    xmlhttp.send();
+  };
 
   setTimeout(() => {
     getTeamIcon();

--- a/recipes/slack/package.json
+++ b/recipes/slack/package.json
@@ -1,7 +1,7 @@
 {
   "id": "slack",
   "name": "Slack",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://{teamId}.slack.com",

--- a/recipes/slack/webview.js
+++ b/recipes/slack/webview.js
@@ -2,37 +2,6 @@ const _path = _interopRequireDefault(require('path'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const getTeamIcon = function getTeamIcon(count = 0) {
-  let countTeamIconCheck = count;
-  let bgUrl = null;
-  const teamMenu = document.querySelector('#team-menu-trigger, .p-ia__sidebar_header__team_name');
-
-  if (teamMenu) {
-    teamMenu.click();
-    const icon = document.querySelector('.c-team_icon');
-
-    if (icon) {
-      bgUrl = window.getComputedStyle(icon, null).getPropertyValue('background-image');
-      bgUrl = /^url\((['"]?)(.*)\1\)$/.exec(bgUrl);
-      bgUrl = bgUrl ? bgUrl[2] : '';
-    }
-
-    setTimeout(() => {
-      document.querySelector('.ReactModal__Overlay').click();
-    }, 10);
-  }
-
-  countTeamIconCheck += 1;
-
-  if (bgUrl) {
-    Ferdi.ipcRenderer.sendToHost('avatar', bgUrl);
-  } else if (countTeamIconCheck <= 5) {
-    setTimeout(() => {
-      getTeamIcon(countTeamIconCheck + 1);
-    }, 2000);
-  }
-};
-
 const SELECTOR_CHANNELS_UNREAD = '.p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted)';
 
 module.exports = Ferdi => {
@@ -43,6 +12,37 @@ module.exports = Ferdi => {
   };
 
   Ferdi.loop(getMessages);
+
+  const getTeamIcon = function getTeamIcon(count = 0) {
+    let countTeamIconCheck = count;
+    let bgUrl = null;
+    const teamMenu = document.querySelector('#team-menu-trigger, .p-ia__sidebar_header__team_name');
+
+    if (teamMenu) {
+      teamMenu.click();
+      const icon = document.querySelector('.c-team_icon');
+
+      if (icon) {
+        bgUrl = window.getComputedStyle(icon, null).getPropertyValue('background-image');
+        bgUrl = /^url\((['"]?)(.*)\1\)$/.exec(bgUrl);
+        bgUrl = bgUrl ? bgUrl[2] : '';
+      }
+
+      setTimeout(() => {
+        document.querySelector('.ReactModal__Overlay').click();
+      }, 10);
+    }
+
+    countTeamIconCheck += 1;
+
+    if (bgUrl) {
+      Ferdi.ipcRenderer.sendToHost('avatar', bgUrl);
+    } else if (countTeamIconCheck <= 5) {
+      setTimeout(() => {
+        getTeamIcon(countTeamIconCheck + 1);
+      }, 2000);
+    }
+  };
 
   setTimeout(() => {
     getTeamIcon();

--- a/recipes/tweetdeck/package.json
+++ b/recipes/tweetdeck/package.json
@@ -1,7 +1,7 @@
 {
   "id": "tweetdeck",
   "name": "Tweetdeck",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://tweetdeck.twitter.com/",

--- a/recipes/tweetdeck/webview.js
+++ b/recipes/tweetdeck/webview.js
@@ -1,9 +1,9 @@
-// Tweetdeck redirect fix
-Ferdi.ipcRenderer.on('redirect-url', (event, url) => {
-  window.location.assign(url);
-});
-
 module.exports = Ferdi => {
+  // Tweetdeck redirect fix
+  Ferdi.ipcRenderer.on('redirect-url', (event, url) => {
+    window.location.assign(url);
+  });
+
   const getMessages = function getMessages() {
     const elements = document.querySelectorAll('.msg-unread-count');
     let count = 0;

--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -2,11 +2,6 @@ const _path = _interopRequireDefault(require('path'));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-window.addEventListener('beforeunload', async () => {
-  Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
-  Ferdi.releaseServiceWorkers();
-});
-
 module.exports = Ferdi => {
   const getMessages = function getMessages() {
     let count = 0;
@@ -33,6 +28,11 @@ module.exports = Ferdi => {
 
     Ferdi.setBadge(count, indirectCount);
   };
+
+  window.addEventListener('beforeunload', async () => {
+    Ferdi.clearStorageData(['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']);
+    Ferdi.releaseServiceWorkers();
+  });
 
   Ferdi.loop(getMessages);
 


### PR DESCRIPTION
Privileged browser APIs should be accessed from `webview.js` via the Ferdi parameter to the exported function.

If any service is broken (e.g., screen sharing), then most likely we have to fix `recipe.js` or `screenshare.js`