### PR TITLE
Toggl recipe: Display 'unread' badge when a timer is running

### DIFF
--- a/recipes/toggl/package.json
+++ b/recipes/toggl/package.json
@@ -1,7 +1,7 @@
 {
   "id": "toggl",
   "name": "toggl",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.toggl.com/app/timer",

--- a/recipes/toggl/webview-unsafe.js
+++ b/recipes/toggl/webview-unsafe.js
@@ -1,0 +1,11 @@
+// only try to update badge once Ferdi API has finished loading
+if (ferdi != undefined && ferdi.setBadge != undefined) {
+    var timerRunning = (window.toggl != undefined) && !!(window.toggl.store.getState().view.timer.timeEntry.start);
+
+    if (timerRunning) {
+        // Treat running timer as a "non-direct" notification (default blue dot instead of urgent red "1")
+        ferdi.setBadge(0, 1);
+    } else {
+        ferdi.setBadge(0);
+    }
+}

--- a/recipes/toggl/webview.js
+++ b/recipes/toggl/webview.js
@@ -1,1 +1,8 @@
-module.exports = Ferdi => Ferdi;
+module.exports = Ferdi => {
+    const path = require('path');
+    const updateBadge = function updateBadge() {
+        Ferdi.injectJSUnsafe(path.join(__dirname, 'webview-unsafe.js'));
+    };
+
+    Ferdi.loop(updateBadge);
+};

--- a/recipes/toggl/webview.js
+++ b/recipes/toggl/webview.js
@@ -1,7 +1,10 @@
+const _path = _interopRequireDefault(require('path'));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 module.exports = Ferdi => {
-    const path = require('path');
     const updateBadge = function updateBadge() {
-        Ferdi.injectJSUnsafe(path.join(__dirname, 'webview-unsafe.js'));
+        Ferdi.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
     };
 
     Ferdi.loop(updateBadge);


### PR DESCRIPTION
This PR adds an "unread" badge to the Toggl service whenever a timer is running.

It uses Toggl's own JavaScript interface — this lets us get away without searching for hardcoded CSS classes in the DOM, but requires passing information between the service context (where the `toggl` object is available) and the Electron context (where the `ferdi` object is available).
Currently, the only way I've found to do that is with `Ferdi.injectJSUnsafe` — and since the `ferdi` object inside the unsafe JS doesn't offer the usual `loop()` function, I have to reinject my JS on every loop…
Is there a more efficient way to do this?

Side note: The Toggl JS interface also exposes the name of the currently running timer, so we could `ferdi.setDialogTitle`, but that doesn't seem to be available in my Ferdi 5.6.1, either…