### PR TITLE
Stop clearing storage data on unload in WhatsApp recipe

### DIFF
--- a/all.json
+++ b/all.json
@@ -1848,7 +1848,7 @@
     "featured": true,
     "id": "whatsapp",
     "name": "WhatsApp",
-    "version": "3.3.6",
+    "version": "3.3.7",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/whatsapp/icon.svg"
     }

--- a/recipes/whatsapp/package.json
+++ b/recipes/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "id": "whatsapp",
   "name": "WhatsApp",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.whatsapp.com",

--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -4,7 +4,7 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
-module.exports = (Ferdi, settings) => {
+module.exports = Ferdi => {
   const getMessages = () => {
     let count = 0;
     let indirectCount = 0;
@@ -48,15 +48,6 @@ module.exports = (Ferdi, settings) => {
   };
 
   window.addEventListener('beforeunload', async () => {
-    Ferdi.clearStorageData(settings.id, {
-      storages: [
-        'appcache',
-        'serviceworkers',
-        'cachestorage',
-        'websql',
-        'indexdb',
-      ],
-    });
     Ferdi.releaseServiceWorkers();
   });
 


### PR DESCRIPTION
Clearing all WhatsApp local stores before unloading was added in https://github.com/meetfranz/recipe-whatsapp/commit/047253c402bd9d81f36eb9905b0d4046a67cf14a for reasons unclear. The new [multi-device beta](https://faq.whatsapp.com/general/download-and-installation/about-multi-device-beta/?lang=en) doesn't seem to like this: reloading WhatsApp causes Ferdi to be stuck on a "Connecting..." screen. Keeping local stores fixes this issue with no apparent drawback.