### PR TITLE
Use the Zoho Mail JS API instead of outdated HTML elements

### DIFF
--- a/all.json
+++ b/all.json
@@ -2028,7 +2028,7 @@
     "featured": false,
     "id": "zoho",
     "name": "Zoho Mail",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/zoho/icon.svg"
     }

--- a/recipes/zoho/package.json
+++ b/recipes/zoho/package.json
@@ -1,7 +1,7 @@
 {
   "id": "zoho",
   "name": "Zoho Mail",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://www.zoho.com/mail/login.html",

--- a/recipes/zoho/webview-unsafe.js
+++ b/recipes/zoho/webview-unsafe.js
@@ -1,0 +1,12 @@
+//wait for Ferdi and Zoho Mail to initialize
+if (
+    Object.prototype.hasOwnProperty.call(window, "ferdi") &&
+    Object.prototype.hasOwnProperty.call(window.ferdi, "setBadge") &&
+    Object.prototype.hasOwnProperty.call(window, "zmNCenter") &&
+    Object.prototype.hasOwnProperty.call(window, "zmfolAction")
+) {
+    var unreadNotifications = window.zmNCenter.counter.count(); //General Notifications by Zoho (Bell Icon)
+    var unreadMail = window.zmfolAction.getUnreadViewCount(); //Unread messages count
+
+    window.ferdi.setBadge(unreadMail, unreadNotifications);
+}

--- a/recipes/zoho/webview.js
+++ b/recipes/zoho/webview.js
@@ -1,10 +1,23 @@
+const _path = _interopRequireDefault(require('path'));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 module.exports = (Ferdi) => {
   const getMessages = () => {
-    const unreadMailInCurrentFolder = $('.zmList.zmLUrd').length;
-    const unreadMailAnyware = $('#zmlTree .zmTreeNDWra .zmBold').length;
-
-    Ferdi.setBadge(unreadMailInCurrentFolder, unreadMailAnyware);
+    Ferdi.injectJSUnsafe(_path.default.join(__dirname, 'webview-unsafe.js'));
   };
 
+  //Zoho uses different URLs for different regions. Find out which region the account belongs to and redirect to the correct URL.
+  const redirectRegion = () => {
+    if (window.location.href === "https://www.zoho.com/mail/login.html") {
+      const btn = document.querySelectorAll(".access-apps");
+      if (btn.length > 0) {
+        window.location.assign(btn[0].href + "zm/");
+      }
+    }
+  }
+
+  window.addEventListener('load', redirectRegion);
   Ferdi.loop(getMessages);
+
 };


### PR DESCRIPTION
Hey all,

the current method for the count of unread e-mails is not working any more, as the  HTML of Zoho Mail changed. This is fixed by my commit, which now uses the JavaScript API of Zoho Mail instead of relying on CSS selectors to find a number in the HTML code.

Additionally, at the moment it is necessary to click a button on a splash screen to access the actual regional web interface of the Zoho account. This commit also adds an automatic redirect to the correct regional URL without requiring any interactions by the user.

Thanks for your work on this project and all the best,
Jonathan Weber