### PR TITLE
Fix Google Drive serviceURL

### DIFF
--- a/recipes/googledrive/package.json
+++ b/recipes/googledrive/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/BrianGilbert/franz-recipe-tawk",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://drive.google.com/",
+    "serviceURL": "https://drive.google.com/drive/my-drive",
     "hasNotificationSound": true
   }
 }


### PR DESCRIPTION
Fixed path to Google Drive. Old path led to a landing page with a link that would redirect to a web browser.