### PR TITLE
fix: show correct count in gmail badge when unread > 999

### DIFF
--- a/recipes/gmail/webview.js
+++ b/recipes/gmail/webview.js
@@ -25,7 +25,7 @@ module.exports = Ferdi => {
         if (parentNodeOfParentNode) {
           const unreadCounts = parentNodeOfParentNode.querySelectorAll('.bsU');
           if (unreadCounts.length > 0) {
-            count = Ferdi.safeParseInt(unreadCounts[0].textContent);
+            count = Ferdi.safeParseInt(unreadCounts[0].textContent.replace(/[^\p{N}]/gu, ''));
           }
         }
       }


### PR DESCRIPTION
Javascript can't parse an int with a comma in it.  This change removes commas
in a way which will work for gmail's badges.  It also removes other non-numeric
characters but it changes the semantics of parseInt such that it will now merge
all numbers in a string and parse them after instead of stopping at the first
non-numeric.  This is appropriate for gmail's badge elements but possibly not
for other places where parseInt can be used so possibly not a good candidate
for promoting to the default behavior of safeParseInt, which is why it's only
implemented here.

This has been tested with the following results:

| Language | works |
|----------|-------|
| Greek    |  yes  |
| French   |  yes  |
| English  |  yes  |
| Russian  |  yes  |
| Bengali  |   no  |

For Bengali, it appears that JS can't parse the numbers at all so it's
not super surprising that it doesn't work to put the number in the badge.

It does, however, extract the numbers so maybe someone who knows i18n in
javascript better than I do (ie, at all) can make the solution more general.

incorrect:
![image](https://user-images.githubusercontent.com/2583421/154159034-dc4f2ab7-8218-4d9d-bcc3-82d94198cbf2.png)

correct:
![image](https://user-images.githubusercontent.com/2583421/154159021-99754222-09c7-4235-b1e9-d241685748d6.png)
