### PR TITLE
Fixing zenhub recipe

### DIFF
--- a/recipes/zenhub/package.json
+++ b/recipes/zenhub/package.json
@@ -6,6 +6,6 @@
   "repository": "https://github.com/mordaroso/recipe-franz-zenhub",
   "config": {
     "hasTeamId": true,
-    "serviceURL": "https://app.zenhub.com/workspace/o/{teamId}/boards"
+    "serviceURL": "https://app.zenhub.com/workspaces/{teamId}/board"
   }
 }


### PR DESCRIPTION
This is the first time I use the ZenHub recipe but it wasn't working out of the box. (Not sure if it was working in the past). As you can see from my commit, the link in the `serviceURL` field was broken, and my update (removing `/o/`, going from `workspace` to `workspaces` and from `boards` to `board`) fixed it.

Also, see screenshot below of a Zenhub instance with the correct link:
![zenhub](https://user-images.githubusercontent.com/4378663/158630808-32dda051-1feb-45e3-b6d2-ab65251f88d1.jpg)

