### PR TITLE
Update Messenger notification counter

### DIFF
--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",

--- a/recipes/messenger/package.json
+++ b/recipes/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "config": {
     "serviceURL": "https://messenger.com",

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -2,32 +2,19 @@ module.exports = Ferdi => {
   const getMessages = () => {
     let count = 0;
 
-    const isNotification = /^\((\d+)\)/.test(document.title);
+    const count_muted = false;
 
     /*
-     * Notification case for group chats, workaround by tamas646
-     * see https://github.com/getferdi/ferdi/issues/1113#issuecomment-783409154
+     * new notification counter by tamas646
      */
-    if (isNotification) {
-      count = Ferdi.safeParseInt(/^\((\d+)\)/.exec(document.title)[1]);
-    } else {
-      /*
-       * Notification case for direct messages, workaround by manavortex
-       * see https://github.com/getferdi/ferdi/issues/1113#issuecomment-846611765
-       */
-      count = document.querySelectorAll(
-        '._5fx8:not(._569x),._1ht3:not(._569x)',
-      ).length;
-      if (count === 0) {
-        count = document.querySelectorAll(
-          '.pq6dq46d.is6700om.qu0x051f.esr5mh6w.e9989ue4.r7d6kgcz.s45kfl79.emlxlaya.bkmhp75w.spb7xbtv.cyypbtt7.fwizqjfa',
-        ).length;
-      }
-      if (count === 0) {
-        // might be obsolete, not sure - never ran into this case
-        count = document.querySelectorAll('[aria-label="Mark as read"]').length;
-      }
+    let notif_indicators = document.querySelectorAll('span.pq6dq46d.is6700om.cyypbtt7.fwizqjfa.s45kfl79.emlxlaya.bkmhp75w.spb7xbtv.qu0x051f.esr5mh6w.e9989ue4.r7d6kgcz');
+    if(count_muted) {
+      count = notif_indicators.length;
     }
+    else {
+      notif_indicators.forEach(span => count += span.parentNode.parentNode.childNodes.length == 1);
+    }
+
     /*
      * add count of message requests on top of notification counter
      */

--- a/recipes/messenger/webview.js
+++ b/recipes/messenger/webview.js
@@ -7,7 +7,7 @@ module.exports = Ferdi => {
     /*
      * new notification counter by tamas646
      */
-    let notif_indicators = document.querySelectorAll('span.pq6dq46d.is6700om.cyypbtt7.fwizqjfa.s45kfl79.emlxlaya.bkmhp75w.spb7xbtv.qu0x051f.esr5mh6w.e9989ue4.r7d6kgcz');
+    let notif_indicators = document.querySelectorAll('span.fxk3tzhb.odagglqh.s9ok87oh.s9ljgwtm.lxqftegz.bf1zulr9.k250bvdn.cv5aopd8.frfouenu.bonavkto.djs4p424.r7bn319e.qmqpeqxj.e7u6y3za.qwcclf47.nmlomj2f');
     if(count_muted) {
       count = notif_indicators.length;
     }


### PR DESCRIPTION
The Messenger's UI changed during the last months, and now we have the ability to count only non-muted chat channels.
Also I guess we don't need the old counting methods anymore...

If you wish to count muted channels too,
you can change the boolean variable back to true.