### PR TITLE
GroupMe badge to exclude muted conversations

### DIFF
--- a/all.json
+++ b/all.json
@@ -701,7 +701,7 @@
     "featured": false,
     "id": "groupme",
     "name": "GroupMe",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/groupme/icon.svg"
     }
@@ -786,7 +786,7 @@
     "featured": false,
     "id": "hostnet",
     "name": "Hostnet",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "icons": {
       "svg": "https://cdn.jsdelivr.net/gh/getferdi/recipes/recipes/hostnet/icon.svg"
     }

--- a/recipes/groupme/package.json
+++ b/recipes/groupme/package.json
@@ -1,7 +1,7 @@
 {
   "id": "groupme",
   "name": "GroupMe",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "config": {
     "serviceURL": "https://web.groupme.com",

--- a/recipes/groupme/webview.js
+++ b/recipes/groupme/webview.js
@@ -1,9 +1,17 @@
 module.exports = Ferdi => {
   const getMessages = () => {
-    const directMessages = document.querySelectorAll('.badge-count:not(.ng-hide)').length;
+    
+    // array-ify the list of conversations
+    const allConversations = [...document.querySelectorAll('#tray .tray-list .list-item')]
+    // for each conversation on the list...
+    const filteredConversations = allConversations.filter(e => {
+      // keep it on the list if [1] it has unread messages (not .ng-hide), and [2] it isn't muted (not .overlay)
+      return (!e.innerHTML.includes('ng-hide') && !e.innerHTML.includes('overlay'))
+    });
+    const unreadConversations = filteredConversations.length;
 
     // set Ferdi badge
-    Ferdi.setBadge(directMessages);
+    Ferdi.setBadge(unreadConversations);
   };
 
   Ferdi.loop(getMessages);

--- a/recipes/hostnet/package.json
+++ b/recipes/hostnet/package.json
@@ -1,7 +1,7 @@
 {
   "id": "hostnet",
   "name": "Hostnet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "config": {
     "serviceURL": "https://appsuite.hostnet.nl/appsuite/"

--- a/recipes/hostnet/webview.js
+++ b/recipes/hostnet/webview.js
@@ -1,6 +1,6 @@
 module.exports = Ferdi => {
   const getMessages = () => {
-    Ferdi.setBadge(parseInt(document.getElementsByClassName('badge topbar-launcherbadge')[0].firstChild.data));
+    Ferdi.setBadge(Number.parseInt(document.querySelectorAll('.badge.topbar-launcherbadge')[0].firstChild.data));
   };
 
   Ferdi.loop(getMessages);


### PR DESCRIPTION
Changed the GroupMe badge counter to exclude muted groups and direct messages.

The .overlay class in a .list-item signifies a muted-bell icon over the sender's profile picture, indicating a muted conversation.