### PR TITLE
Fix The Lounge badge number so it ignores muted channels

### DIFF
--- a/recipes/thelounge/package.json
+++ b/recipes/thelounge/package.json
@@ -1,7 +1,7 @@
 {
   "id": "thelounge",
   "name": "The Lounge",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "config": {
     "hasCustomUrl": true,

--- a/recipes/thelounge/webview.js
+++ b/recipes/thelounge/webview.js
@@ -51,7 +51,9 @@ module.exports = Ferdi => {
       '.badge:not(.highlight)',
     );
     for (const indirectElement of indirectElements) {
-      if (indirectElement.parentElement.classList.contains('is-muted')) {
+      const channelListItem = indirectElement.closest('.channel-list-item');
+      
+      if (channelListItem === null || channelListItem.classList.contains('is-muted')) {
         // Ignore muted channels
         continue;
       }

--- a/recipes/thelounge/webview.js
+++ b/recipes/thelounge/webview.js
@@ -40,6 +40,7 @@ module.exports = Ferdi => {
     var directElements = document.querySelectorAll('.badge.highlight');
 
     for (const directElement of directElements) {
+      // Note: muted channels don't have highlighted badges
       if (directElement.textContent.length > 0) {
         direct += Ferdi.safeParseInt(directElement.textContent);
       }
@@ -50,6 +51,11 @@ module.exports = Ferdi => {
       '.badge:not(.highlight)',
     );
     for (const indirectElement of indirectElements) {
+      if (indirectElement.parentElement.classList.contains('is-muted')) {
+        // Ignore muted channels
+        continue;
+      }
+
       if (indirectElement.textContent.length > 0) {
         indirect++;
       }


### PR DESCRIPTION
This PR fixes a bug in the recipe for The Lounge where it would include muted channels when calculating its badge number.