### PR TITLE
Update proton mail recipe

### DIFF
--- a/recipes/proton-mail/icon.svg
+++ b/recipes/proton-mail/icon.svg
@@ -1,1 +1,28 @@
-<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><g fill="#336" fill-rule="nonzero"><path d="M511.603 1.032S210.169-8.87 148 325.503v227.74s2.571 24.373 71.122 73.881S465.142 816.02 511.603 816.02s223.931-139.386 292.481-188.895 71.122-73.882 71.122-73.882V325.503C813.036-8.87 511.603 1.032 511.603 1.032zm206.413 448.623H305.19V325.503c41.892-166.044 206.413-168.329 206.413-168.329s164.52 2.285 206.413 168.33z"/><path d="M511.603 867.305s-46.716-4.572-83.276-29.96S148 637.788 148 637.788V982.57s2.064 40.115 46.241 40.115h634.724c44.177 0 46.241-40.115 46.241-40.115V637.788s-243.768 174.17-280.328 199.557-83.275 29.96-83.275 29.96z"/></g></svg>
+<svg width="106" height="86" viewBox="0 0 106 86" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M83.4613 16.1551V86H95.0393C101.094 86 106 81.026 106 74.9015V2.47101C106 0.378398 103.596 -0.761032 102.003 0.575608L83.4613 16.1551Z"
+        fill="url(#paint0_linear_10975_186582)"/>
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M67.3128 29.7407L46.1604 48.6618C42.5538 51.8829 37.1709 51.9596 33.4777 48.848L0 20.6691V2.482C0 0.38939 2.40441 -0.760996 3.99653 0.575643L45.998 35.8761C50.0595 39.2944 55.9514 39.2944 60.0129 35.8761L67.3128 29.7407Z"
+        fill="url(#paint1_linear_10975_186582)"/>
+  <path
+    d="M83.4613 16.1661L67.3128 29.7407L67.3236 29.7406L46.1604 48.6618C42.5538 51.8829 37.1709 51.9596 33.4777 48.848L0 20.6691V74.9015C0 81.0259 4.9063 86 10.9607 86L83.4613 86V16.1661Z"
+    fill="url(#paint2_radial_10975_186582)"/>
+  <defs>
+    <linearGradient id="paint0_linear_10975_186582" x1="265.975" y1="141.754" x2="244.3" y2="-73.4041"
+                    gradientUnits="userSpaceOnUse">
+      <stop offset="0.271" stop-color="#E3D9FF"/>
+      <stop offset="1" stop-color="#7341FF"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear_10975_186582" x1="62.6346" y1="86.7984" x2="18.553" y2="-87.2799"
+                    gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E3D9FF"/>
+      <stop offset="1" stop-color="#7341FF"/>
+    </linearGradient>
+    <radialGradient id="paint2_radial_10975_186582" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+                    gradientTransform="translate(105.538 10.5272) scale(123.614 125.045)">
+      <stop offset="0.5561" stop-color="#6D4AFF"/>
+      <stop offset="0.9944" stop-color="#AA8EFF"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/recipes/proton-mail/package.json
+++ b/recipes/proton-mail/package.json
@@ -1,9 +1,9 @@
 {
   "id": "proton-mail",
   "name": "ProtonMail",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://mail.protonmail.com/login"
+    "serviceURL": "https://account.proton.me/login"
   }
 }


### PR DESCRIPTION
### 🔧 Changes

ProtonMail rebranded themselves and changed their service URL from `https://mail.proton.me/login` to `https://account.proton.me/login` and logos as well. This PR brings the current recipe up to date with those changes. 

### 📚 References

- https://proton.me/blog/updated-proton

### 🔬 Testing

- Tested this locally on linux. 
